### PR TITLE
Unset android:enableOnBackInvokedCallback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <application
         android:allowBackup="true"
-        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_scheme"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
It doesn't want to close menus for whatever reason (?)

Test:
* Open app and search for some picture
* Now click on result with menu
* Try clicking back and notice that now the menu gets closed automatically.

Closes: #45